### PR TITLE
Add query params to DB method calls.

### DIFF
--- a/python/ics/utils/opdb.py
+++ b/python/ics/utils/opdb.py
@@ -12,27 +12,27 @@ class opDB:
         return psycopg2.connect(dbname='opdb', user='pfs', host=opDB.host)
 
     @staticmethod
-    def fetchall(query):
+    def fetchall(query, params=None):
         """ fetch all rows from query """
         with opDB.connect() as conn:
             with conn.cursor() as curs:
-                curs.execute(query)
+                curs.execute(query, params)
                 return np.array(curs.fetchall())
 
     @staticmethod
-    def fetchone(query):
+    def fetchone(query, params=None):
         """ fetch one row from query """
         with opDB.connect() as conn:
             with conn.cursor() as curs:
-                curs.execute(query)
+                curs.execute(query, params)
                 return np.array(curs.fetchone())
 
     @staticmethod
-    def commit(query, kwargs):
+    def commit(query, params=None):
         """ execute query and commit """
         with opDB.connect() as conn:
             with conn.cursor() as curs:
-                curs.execute(query, kwargs)
+                curs.execute(query, params)
             conn.commit()
 
     @staticmethod


### PR DESCRIPTION
* Support params passed to the various fetch methods, which is the preferred psycopg2 way of handling params.
* These are optional at this point and shouldn't affect anything. I did not change the existing calls, which currently build up a query with f-strings.