### PR TITLE
Modernize the repo - tickets/INSTRM-2640

### DIFF
--- a/.github/workflows/pip-install.yml
+++ b/.github/workflows/pip-install.yml
@@ -1,0 +1,33 @@
+name: Pip install check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pip-install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Upgrade pip and wheel
+        run: |
+          python -m pip install --upgrade pip wheel
+
+      - name: Install build-time helper (lsst-versions)
+        run: |
+          python -m pip install lsst-versions
+
+      - name: Install package with pip
+        run: |
+          python -m pip install .
+
+      - name: Verify import
+        run: |
+          python -c "import ics.utils as u; print('Imported ics.utils from:', u.__file__)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,171 @@
-*.pyc
-.idea
+### JetBrains template
+.idea/
+
+# CMake
+cmake-build-*/
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JupyterNotebooks template
+# gitignore template for Jupyter Notebooks
+# website: http://jupyter.org/
+
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/
+
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,115 @@
+# ics_utils - ICS utility package
+
+Common utility tools for the Subaru Prime Focus Spectrograph (PFS) Instrument Control System (ICS).
+
+## Overview
+
+- This package provides shared Python utilities used by PFS ICS actors and related services.
+- It includes helpers for FITS file writing and metadata, database access, instrument configuration and data access,
+  state machines, TCP communication, spectrograph subsystems (lamps and PDU), visit/field bookkeeping, and more.
+- The repository also contains Lua scripts for Digital Loggers power devices used by some subsystems.
+
+## Features
+
+- FITS utilities
+    - Structured FITS writer for PFS-specific headers and data (ics.utils.fits)
+    - WCS/timecards helpers and convenience functions
+- Finite State Machine (FSM)
+    - Lightweight FSM framework used by actors/threads (ics.utils.fsm)
+- Instrument data/config
+    - Access to actor/instrument configuration and persistent data (ics.utils.instdata)
+- TCP utilities
+    - Buffered sockets and convenience methods (ics.utils.tcp)
+- Spectrograph (SPS) helpers
+    - Lamps and PDU abstractions, controllers (including Digital Loggers/Aten), simulators, and command helpers (
+      ics.utils.sps)
+- Visit management
+    - Visit/field data structures and manager utilities (ics.utils.visit)
+- Misc utilities
+    - Time, threading helpers, MHS integration, logbook support, versions helper
+
+## Installation
+
+> Note: This package is mostly used by other ICS actors and services, so direct installation may not be necessary unless
+> you are developing or testing it independently.
+
+### Requirements
+
+- Python: >= 3.11
+- Core dependencies (installed automatically):
+    - numpy, scipy, pandas, astropy, astropy_iers_data
+    - fitsio
+    - pytz
+    - gitpython
+    - twisted
+    - psycopg2-binary
+    - sdss-opscore, sdss-actorcore
+
+### EUPS Installation with LSST Stack
+
+This package uses the Extended Unix Product System (EUPS) for dependency management and environment setup, which is part
+of the LSST Science Pipelines software stack. The LSST stack is a comprehensive framework for astronomical data
+processing that provides powerful tools for image processing, astrometry, and data management.
+
+1. Ensure you have the LSST stack installed on your system. If not, follow the installation instructions at
+   the [LSST Science Pipelines documentation](https://pipelines.lsst.io/install/index.html).
+
+2. Once the LSST stack is set up, declare and setup this package using EUPS:
+   ```
+   eups declare -r /path/to/ics_utils ics_utils git
+   setup -r /path/to/ics_utils
+   ```
+
+### Standard Setup
+
+Alternatively, you can install the package using pip:
+
+1. Clone the repository:
+   ```
+   git clone https://github.com/Subaru-PFS/ics_utils.git
+   ```
+
+2. Install the package:
+   ```
+   cd ics_utils
+   pip install .
+   ```
+
+## Usage
+
+This package is intended to be used as a library within the PFS ICS ecosystem.
+
+## Project Structure
+
+- python/ics/utils/
+    - fits/: FITS writing helpers
+    - fsm/: FSM utilities
+    - instdata/: instrument/actor configuration and IO
+    - sps/: spectrograph related helpers (lamps, PDU, parts, spectra IDs)
+    - tcp/: TCP socket helpers
+    - visit/: visit and field models and manager
+    - time.py, threading.py, opdb.py, logbook.py, versions.py, etc.
+- lua/digitalLoggers/: Lua scripts for Digital Loggers devices
+
+## Development
+
+### Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Submit a pull request
+
+### Versioning
+
+This project follows semantic versioning.
+
+## License
+
+This project is part of the Subaru Prime Focus Spectrograph (PFS) project and is subject to the licensing terms of the
+PFS collaboration.
+
+## Contact
+
+For questions or issues related to this software, please contact the PFS software team or create an issue in the
+repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools >= 77.0.3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pfs-ics-utils"
+description = "Common util tools for the Subaru ICS actors"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "numpy",
+    "astropy",
+    "pytz",
+    "pandas",
+    "psycopg2-binary",
+    "scipy",
+    "fitsio",
+    "gitpython",
+    "twisted",
+    "sdss-opscore",
+    "sdss-actorcore",
+    "astropy_iers_data",
+]
+dynamic = ["version"]
+
+[tool.setuptools.packages.find]
+where = ["python/"]
+include = ["ics", "ics.*"]
+
+[tool.black]
+line-length = 110
+target-version = ["py311"]
+
+[tool.isort]
+profile = "black"
+line_length = 110
+known_first_party = ["ics"]
+
+[tool.lsst_versions]
+write_to = "python/ics/utils/version.py"
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"  # Recommended as best practice
+
+[tool.pydocstyle]
+convention = "numpy"


### PR DESCRIPTION
* Adds a `pyproject.toml` file for pip installation.
  * Sets minimum python version to 3.11.
  * Doesn't specify a mininum numpy version.
* Adds a README.
* Updates the `.gitignore`.
* Add a basic GHA workflow to test pip install.